### PR TITLE
Fix admin workflows for handle-based student keys

### DIFF
--- a/admin_flows.py
+++ b/admin_flows.py
@@ -595,13 +595,14 @@ async def handle_student_action(update: Update, context: ContextTypes.DEFAULT_TY
         return
     await query.answer()
     logging.debug("handle_student_action data=%s", query.data)
-    match = re.match(
-        r"^stu:(LOG|CANCEL|RESHED|RENEW|RENEW_SAME|RENEW_ENTER|LENGTH|EDIT|FREECREDIT|PAUSE|REMOVE|VIEW|ADHOC):([^:]+)$",
-        query.data,
-    )
-    if not match:
+    data = query.data or ""
+    if not data.startswith("stu:"):
         return
-    action, student_id = match.group(1), match.group(2)
+    try:
+        _, action, student_id = data.split(":", 2)
+    except ValueError:
+        logging.warning("Malformed student action callback: %s", data)
+        return
     student = data_store.get_student_by_id(student_id)
     if not student:
         await safe_edit_or_send(query, STUDENT_NOT_FOUND_MSG)

--- a/keyboard_builders.py
+++ b/keyboard_builders.py
@@ -7,6 +7,7 @@ def build_student_submenu(student_id: str) -> InlineKeyboardMarkup:
 
     Callback data strings follow the ``stu:<ACTION>:<id>`` convention.
     """
+    student_id = str(student_id)
     buttons = [
         [
             InlineKeyboardButton("✅ Log Class", callback_data=f"stu:LOG:{student_id}"),


### PR DESCRIPTION
## Summary
- allow admin student action callbacks to parse non-numeric keys and resolve canonical student records
- normalize admin submenu button IDs and widen admin pick callback pattern to cover handle-backed students
- persist purge removals safely and guard removal logging against stub timezone types

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cae7e6534c8327a552e18871a169d5