### PR TITLE
Prevent overwriting students when connecting Telegram

### DIFF
--- a/class_track_bot.py
+++ b/class_track_bot.py
@@ -4305,6 +4305,11 @@ async def process_connect_student_reply(
     if telegram_id:
         new_key = str(int(telegram_id))
     if new_key != student_key:
+        if new_key in students:
+            await update.message.reply_text(
+                "❌ Error: A student with that Telegram ID already exists. Please check the ID and try again."
+            )
+            return
         students.pop(student_key, None)
     students[new_key] = student
     save_students(students)


### PR DESCRIPTION
## Summary
- prevent connect-to-Telegram flow from overwriting existing students by checking for ID collisions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc116b4bdc83279ae0b91f1fd90bc8