### PR TITLE
Rename dashboard today classes section

### DIFF
--- a/class_track_bot.py
+++ b/class_track_bot.py
@@ -2073,7 +2073,7 @@ def generate_dashboard_summary() -> str:
     )
     lines.append(f"Total scheduled hours/week: {total_hours:.1f}")
     lines.append("")
-    lines.append(f"Today's classes ({fmt_bkk(today)}):")
+    lines.append(f"Unlogged classes (today) ({fmt_bkk(today)}):")
     if today_classes:
         lines.extend(f"- {item}" for item in today_classes)
     else:


### PR DESCRIPTION
## Summary
- rename the dashboard summary section label to clarify it highlights unlogged classes for today

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce322b05e88327851b1935859490e9