### PR TITLE
Limit cancellable classes for non-premium students

### DIFF
--- a/class_track_bot.py
+++ b/class_track_bot.py
@@ -911,7 +911,18 @@ def get_student_cancellable_classes(student: Dict[str, Any]) -> List[datetime]:
             continue
         results.append(dt)
     results.sort()
-    return results
+    if is_premium(student):
+        return results
+
+    remaining_raw = student.get("classes_remaining")
+    try:
+        remaining = int(remaining_raw)
+    except (TypeError, ValueError):
+        remaining = 0
+    if remaining < 0:
+        remaining = 0
+
+    return results[:remaining]
 
 
 def get_admin_visible_classes(

--- a/tests/test_student_visible_classes.py
+++ b/tests/test_student_visible_classes.py
@@ -173,11 +173,11 @@ def test_student_visible_classes_premium_unlimited():
     assert visible == expected
 
 
-def test_student_cancellable_classes_ignores_remaining():
-    student, class_dates = _build_student(classes_remaining=0)
+def test_student_cancellable_classes_respects_remaining():
+    student, class_dates = _build_student(classes_remaining=1)
     cancellable = ctb.get_student_cancellable_classes(student)
-    assert len(cancellable) == len(class_dates)
-    expected = [ctb.ensure_bangkok(dt) for dt in class_dates]
+    assert len(cancellable) == 1
+    expected = [ctb.ensure_bangkok(dt) for dt in class_dates[:1]]
     assert cancellable == expected
 
 


### PR DESCRIPTION
## Summary
- restrict cancellable class options for non-premium students to their paid balance
- leave premium students unaffected by the new filtering logic
- update cancellable class tests to cover the new behavior

## Testing
- pytest tests/test_student_visible_classes.py

------
https://chatgpt.com/codex/tasks/task_e_68e2b36d5f708327a4dd54f0b7dd36eb